### PR TITLE
Extract webpack-dev-server from server.js to npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,19 @@ A core philosophy of this skeleton app is to keep the tooling to a minimum. For 
 $ npm run server
 ```
 
+Starts the server in production mode (uses the minified app from the `build` script).
+
+Listening port can be specified using the `PORT` enviroment variable (e.g. `PORT=80 npm run server`). Default port is 8080
+
+### dev
+
+```sh
+$ npm run dev
+```
+
 **Input:** `src/main.jsx`
 
-This leverages [React Hot Loader](https://github.com/gaearon/react-hot-loader) to automatically start a local dev server and refresh file changes on the fly without reloading the page.
+This leverages [React Hot Loader](https://github.com/gaearon/react-hot-loader) to automatically start a local dev server and refresh file changes on the fly without reloading the page. The server is also automatically restarted when it is changed, using [nodemon](https://github.com/remy/nodemon).
 
 It also automatically includes source maps, allowing you to browse code and set breakpoints on the original ES6 code:
 

--- a/build/index.html
+++ b/build/index.html
@@ -11,10 +11,6 @@
     user = false;
   </script>
 
-  <!-- For local development -->
-  <script src="http://localhost:9090/build/app.js"></script>
-
-  <!-- For production -->
-  <!-- <script src="app.js"></script> -->
+  <script src="app.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "server": "node server.js",
     "build": "webpack -p --config webpack.production.config.js",
+    "webpack-dev-server": "webpack-dev-server --content-base-target http://localhost:8081/ --hot --inline --quiet --config=webpack.local.config.js",
+    "server-dev": "PORT=8081 nodemon -q --ignore src/ --ignore build/ server.js",
+    "dev": "npm run server-dev & npm run webpack-dev-server",
     "test": "PHANTOMJS_BIN=./node_modules/.bin/phantomjs ./node_modules/karma/bin/karma start karma.config.js",
     "coveralls": "cat coverage/lcov.info | coveralls",
     "clean": "rm build/app.js"
@@ -30,7 +33,6 @@
     "babel-core": "^4.7.8",
     "babel-loader": "^4.1.0",
     "coveralls": "^2.11.2",
-    "express": "^4.12.2",
     "istanbul": "^0.3.7",
     "istanbul-instrumenter-loader": "^0.1.2",
     "karma": "^0.12.31",
@@ -39,13 +41,15 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon-chai": "^0.3.0",
     "karma-webpack": "^1.5.0",
+    "nodemon": "^1.3.7",
     "phantomjs": "^1.9.16",
     "react-hot-loader": "^1.2.3",
     "webpack": "^1.7.2",
-    "webpack-dev-server": "^1.7.0"
-  },
-  "dependencies": {
+    "webpack-dev-server": "^1.7.0",
     "react": "^0.12.2",
     "react-router": "^0.12.4"
+  },
+  "dependencies": {
+    "express": "^4.12.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,11 +1,6 @@
 var express = require('express');
 var app = express();
 
-var webpack = require('webpack');
-var WebpackDevServer = require('webpack-dev-server');
-var config = require('./webpack.local.config');
-
-
 /************************************************************
  *
  * Express routes for:
@@ -16,6 +11,11 @@ var config = require('./webpack.local.config');
  *     - POST /home
  *
  ************************************************************/
+
+// Serve app file
+app.get('/app.js', function(req, res) {
+  res.sendFile(__dirname + '/build/app.js');
+});
 
 // Serve index page
 app.get('*', function(req, res) {
@@ -34,33 +34,13 @@ app.post('/home', function(req, res) {
   });
 });
 
-
-/*************************************************************
- *
- * Webpack Dev Server
- *
- * See: http://webpack.github.io/docs/webpack-dev-server.html
- *
- *************************************************************/
-
-new WebpackDevServer(webpack(config), {
-  publicPath: config.output.publicPath,
-  hot: true,
-  noInfo: true,
-  historyApiFallback: true
-}).listen(9090, 'localhost', function (err, result) {
-  if (err) {
-    console.log(err);
-  }
-});
-
 /******************
  *
  * Express server
  *
  *****************/
 
-var server = app.listen(8080, function () {
+var server = app.listen(process.env.PORT || 8080, function () {
   var host = server.address().address;
   var port = server.address().port;
 

--- a/webpack.local.config.js
+++ b/webpack.local.config.js
@@ -16,23 +16,18 @@ module.exports = {
   devtool: "eval",
 
   // Set entry point to ./src/main and include necessary files for hot load
-  entry:  [
-    "webpack-dev-server/client?http://localhost:9090",
-    "webpack/hot/only-dev-server",
-    "./src/main"
-  ],
+  entry: "./src/main",
 
   // This will not actually create a bundle.js file in ./build. It is used
   // by the dev server for dynamic hot loading.
   output: {
     path: __dirname + "/build/",
     filename: "app.js",
-    publicPath: "http://localhost:9090/build/"
+    publicPath: "/"
   },
 
   // Necessary plugins for hot load
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],
 


### PR DESCRIPTION
This allows the `server.js` to be independent from webpack-dev-server. Since it allows to reload the server without breaking the hot-loader, I also added `nodemon`, in order to automatically reload the server when a file changes.

Technically, the `server.js` listens to the `8081` port, and the `webpack-dev-server` (which is listening to `8080`) creates a proxy to the server (using the `content-base-taget` option)

It also allows to have the same `index.html` file in dev and production environment, because the dev-server and the production-server are listening to the same port

To launch the server with webpack-dev-server and nodemon, use the `dev` npm script.

PS: Sorry if I did any spelling error in the README file or in this PR, I'm French :no_mouth: 
