### PR TITLE
Add Radium

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,26 +9,16 @@ import "babel-core/polyfill";
 import React from "react";
 import Router from "react-router";
 
-// Common utilities
-import Session from "./common/session";
 
 // Routers
-import LoggedOutRouter from "./routers/logged_out";
-import LoggedInRouter from "./routers/logged_in";
+import AppRouter from "./routers/app";
 
 
 // ID of the DOM element to mount app on
 const DOM_APP_EL_ID = "app";
 
 
-// Initialize routes depending on session
-let routes;
-
-if (Session.isLoggedIn()) {
-  routes = LoggedInRouter.getRoutes();
-} else {
-  routes = LoggedOutRouter.getRoutes();
-}
+let routes = AppRouter.getRoutes();
 
 /**
  * Given a set of routes and params associated with the current active state,

--- a/src/pages/home/page.jsx
+++ b/src/pages/home/page.jsx
@@ -1,8 +1,13 @@
 import React from "react";
 import { getData } from "../../common/request";
+// import { MatchMediaItem } from "radium"
 
 
 export default class HomePage extends React.Component {
+  // constructor() {
+  //   this.mixins = [MatchMediaItem]
+  // }
+
   componentWillMount() {
     console.log("[HomePage] will mount with server response: ", this.props.data.home);
   }

--- a/src/pages/landing/page.jsx
+++ b/src/pages/landing/page.jsx
@@ -1,8 +1,13 @@
 import React from "react";
 import { getData } from "../../common/request";
+// import { MatchMediaItem } from "radium"
 
 
 export default class LandingPage extends React.Component {
+  // constructor() {
+  //   this.mixins = [MatchMediaItem]
+  // }
+
   componentWillMount() {
     console.log("[LandingPage] will mount with server response: ", this.props.data.landing);
   }

--- a/src/routers/app.jsx
+++ b/src/routers/app.jsx
@@ -9,7 +9,21 @@ import LoggedInRouter from "./logged_in";
 import Session from "../common/session";
 
 
+// Media queries
+// import { MatchMediaBase } from "radium"
+
+
+// MatchMediaBase.init({
+//   sm: "(min-width: 768px)",
+//   md: "(min-width: 992px)",
+//   lg: "(min-width: 1200px)"
+// });
+
 export default class AppRouter extends React.Component {
+  constructor() {
+    // this.mixins = [MatchMediaBase]
+  }
+
   render() {
     return (
       <RouteHandler {...this.props} />

--- a/src/routers/app.jsx
+++ b/src/routers/app.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Route, RouteHandler } from "react-router";
+
+// Routers
+import LoggedOutRouter from "./logged_out";
+import LoggedInRouter from "./logged_in";
+
+// Common utilities
+import Session from "../common/session";
+
+
+export default class AppRouter extends React.Component {
+  render() {
+    return (
+      <RouteHandler {...this.props} />
+    );
+  }
+}
+
+AppRouter.getRoutes = function() {
+  let routes;
+
+  if (Session.isLoggedIn()) {
+    routes = LoggedInRouter.getRoutes();
+  } else {
+    routes = LoggedOutRouter.getRoutes();
+  }
+
+  return (
+    <Route name="app" path="/" handler={AppRouter}>
+      {routes}
+    </Route>
+  );
+}

--- a/src/routers/logged_in.jsx
+++ b/src/routers/logged_in.jsx
@@ -27,7 +27,7 @@ export default class LoggedInRouter extends React.Component {
 
 LoggedInRouter.getRoutes = function() {
   return (
-    <Route name="app" path="/" handler={LoggedInRouter}>
+    <Route handler={LoggedInRouter}>
       <DefaultRoute name="home" handler={HomePage} />
     </Route>
   );

--- a/src/routers/logged_out.jsx
+++ b/src/routers/logged_out.jsx
@@ -19,7 +19,7 @@ export default class LoggedOutRouter extends React.Component {
 
 LoggedOutRouter.getRoutes = function() {
   return (
-    <Route name="app" path="/" handler={LoggedOutRouter}>
+    <Route handler={LoggedOutRouter}>
       <DefaultRoute name="landing" handler={LandingPage} />
     </Route>
   );


### PR DESCRIPTION
This pull request intends to address #2.

Despite Radium not yet being compatible with React 0.13 (https://github.com/FormidableLabs/radium/issues/92), I think there are other implications that can be discussed in the meantime.

The [Radium docs](https://github.com/formidablelabs/radium/blob/master/docs/guides/media-q
ueries.md) say this:

> To start, choose a high level component in your app where you will initialize your media queries. Any components that should use your media queries should be descendents of this component.

**Note:** this means descendent as in view hierarchy, not class inheritance.

Since this project didn't have a single high level component, the first commit introduces an app router which is loosely based on the [shared root example](https://github.com/rackt/react-router/blob/master/examples/shared-root/a
pp.js) from React Router.

While there are further potential changes in this area to bring Essential React closer to the given example, those are not (yet) addressed here.

The second commit outlines how Radium could/would be added. These changes have been left as comments in order to keep the project compatible with 0.13 and allow any further refactoring of components.

---
#### Concerns
- It seems odd to be setting up media queries inside a router but I'm not sure if/how a high level app component can be introduced in another way.
- Although the `MatchMediaItem` mixin is being applied to _pages_ I did wonder if it should instead be applied to `LoggedInRouter` and `LoggedOutRouter`.

Should the project be refactored and brought closer to the React Router example, some of these concerns might be redundant.

---

There are other aspects to Radium which have little (if any) implications and have yet to be implemented for that reason.

Looking for some input from @pheuter on how best to proceed.
