### PR TITLE
package.json no longer sets a PHANTOM_JS_BIN environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+.idea

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "npm run build",
     "server": "node server.js",
     "build": "webpack -p --config webpack.production.config.js",
-    "test": "PHANTOMJS_BIN=./node_modules/.bin/phantomjs ./node_modules/karma/bin/karma start karma.config.js",
+    "test": "karma start karma.config.js",
     "test-cross-browser": "./node_modules/karma/bin/karma start karma.cross-browser.config.js",
     "coveralls": "cat coverage/lcov.info | coveralls",
     "clean": "rm build/app.js"


### PR DESCRIPTION
This would make the framework more OS-agnostic, as the environment variable here appears to be redundant, and breaks on a Windows machine.
