### PR TITLE
Fix for issue #37 - hot reload of css files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "coveralls": "^2.11.2",
     "css-loader": "^0.18.0",
     "enzyme": "^2.0.0",
-    "extract-text-webpack-plugin": "^0.8.2",
     "nyc": "^5.6.0",
     "postcss-loader": "^0.6.0",
     "postcss-nested": "^1.0.0",

--- a/webpack.local.config.js
+++ b/webpack.local.config.js
@@ -1,5 +1,4 @@
 var webpack = require('webpack');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 /**
  * This is the Webpack configuration file for local development. It contains
@@ -34,15 +33,14 @@ module.exports = {
   // Necessary plugins for hot load
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(),
-    new ExtractTextPlugin('style.css', { allChunks: true })
+    new webpack.NoErrorsPlugin()
   ],
 
   // Transform source code using Babel and React Hot Loader
   module: {
     loaders: [
       { test: /\.jsx?$/, exclude: /node_modules/, loaders: ["react-hot", "babel-loader"] },
-      { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader') }
+      { test: /\.css$/,  loaders: ['style?singleton', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]', 'postcss']}
     ]
   },
 

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -1,5 +1,4 @@
 var webpack = require('webpack');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 /**
  * This is the Webpack configuration file for production.
@@ -12,14 +11,10 @@ module.exports = {
     filename: "app.js"
   },
 
-  plugins: [
-    new ExtractTextPlugin('style.css', { allChunks: true })
-  ],
-
   module: {
     loaders: [
-      { test: /\.jsx?$/, exclude: /node_modules/, loader: "babel-loader" },
-      { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader') }
+      { test: /\.jsx?$/, exclude: /node_modules/, loaders: ["react-hot", "babel-loader"] },
+      { test: /\.css$/,  loaders: ['style?singleton', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]', 'postcss']}
     ]
   },
 


### PR DESCRIPTION
I have removed ExtractTextPlugin from package.json and webpack configs, because it doesn't support css hot reloading. 

Without it, css hot reload works. This should resolve issue #37 - live reload of css files.
