### PR TITLE
build production version in travis; run against node 4,5,6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+sudo: false
 language: node_js
 node_js:
-  - "4.1"
+  - 4
+  - 5
+  - 6
+script:
+  - npm test
+  - npm run build
 after_script:
   - npm run coveralls
 env:


### PR DESCRIPTION
- run against node 4, 5, 6
- make sure building production version of app succeeds
- `sudo: false` is recommended by Travis; then it uses their docker setup I believe

Build is passing with this setup, eg: https://travis-ci.org/harlantwood/essential-react/builds/130282326
